### PR TITLE
Update and fix the daystrip extension

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: theeventscalendar
 Donate link: https://evnt.is/29
 Tags: events, calendar
 Requires at least: 5.0
-Tested up to: 5.7
-Requires PHP: 7.0
-Stable tag: 1.0.1
+Tested up to: 6.3.2
+Requires PHP: 7.4
+Stable tag: 1.1.0
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -30,6 +30,12 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.1.0] 2023-11-06 =
+
+* Fix - Make sure that all options have a default value, so the extension can be used right after activation.
+* Fix - Now the day and month names show up on the day-to-day navigation bar from the start.
+* Fix - The event marker now properly shows up on days with events.
 
 = [1.0.1] 2021-04-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 * Fix - Make sure that all options have a default value, so the extension can be used right after activation.
 * Fix - Now the day and month names show up on the day-to-day navigation bar from the start.
 * Fix - The event marker now properly shows up on days with events.
+* Tweak - There is now no warning message when saving the settings with an empty Start Date field.
 
 = [1.0.1] 2021-04-14 =
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -228,6 +228,7 @@ if ( ! class_exists( Settings::class ) ) {
 					'tooltip'         => sprintf( esc_html__( "Use YYYY-MM-DD format. Works only with the option '%sShow fixed number of days starting on a specific date%s'.", 'tribe-ext-daystrip' ), '<em>', '</em>' ) . '<br/><em>' . esc_html__( 'Default value:', 'tribe-ext-daystrip') . ' 2</em>',
 					'validation_type' => 'alpha_numeric_with_dashes_and_underscores',
 					'size'            => 'medium',
+					'can_be_empty'    => true,
 				],
 				'length_of_day_name' => [
 					'type'            => 'text',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -197,7 +197,7 @@ if ( ! class_exists( Settings::class ) ) {
 			$fields = [
 				'Example'   => [
 					'type' => 'html',
-					'html' => $this->get_example_intro_text(),
+					'html' => $this->get_daystrip_intro_text(),
 				],
 				'full_width' => [
 					'type'            => 'checkbox_bool',
@@ -325,8 +325,8 @@ if ( ! class_exists( Settings::class ) ) {
 		 *
 		 * @return string
 		 */
-		private function get_example_intro_text() {
-			return '<h3>' . esc_html_x( 'Day Strip Extension Settings', 'Settings header', 'tribe-ext-daystrip' ) . '</h3>';
+		private function get_daystrip_intro_text() {
+			return '<h3 id="tec-settings-events-settings-display-daystrip">' . esc_html_x( 'Day Strip Extension Settings', 'Settings header', 'tribe-ext-daystrip' ) . '</h3>';
 		}
 
 	} // class

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -302,7 +302,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 				} // Fixed time range from set date
 				elseif ( $options['behavior'] == 'fixed_from_date' ) {
 					$start_date = $options['start_date'] ?? $args['todays_date'];
-					$sd = explode( '-', $start_date );
+					$sd         = explode( '-', $start_date );
 					if ( checkdate( $sd[1], $sd[2], $sd[0] ) ) {
 						$args['starting_date'] = $start_date;
 					} else {
@@ -324,12 +324,11 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 					$args['starting_date'] = date( 'Y-m-d', strtotime( 'next week' . $this->adjust_week_start() ) );
 					$args['days_to_show']  = 7;
 				} // Default, selected day in the middle
-				else {
-					// Choosing the starting date for the array and formatting it
-					$args['starting_date'] = date( 'Y-m-d',
-						strtotime( $args['selected_date_value'] . ' -' . intdiv( $args['days_to_show'],
-								2 ) . ' days' ) );
-				}
+			} else {
+				// Choosing the starting date for the array and formatting it
+				$args['starting_date'] = date( 'Y-m-d',
+					strtotime( $args['selected_date_value'] . ' -' . intdiv( $args['days_to_show'],
+							2 ) . ' days' ) );
 			}
 
 			// Creating and filling the array of days that we show

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -380,7 +380,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 			$events = tribe_get_events( $args );
 
 			foreach ( $events as $event ) {
-				$d = date( 'Y-m-d', strtotime( $event->event_date ) );
+				$d = tribe_get_start_date( $event->ID, false, 'Y-m-d' );
 				if ( ! in_array( $d, $dates ) ) {
 					$dates[] = $d;
 				}
@@ -403,7 +403,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 			}
 			// If Tuesday (2) to Saturday (6)
 			elseif( $first_day_of_week > 1 ) {
-				$str = " +" . $first_day_of_week - 1 . " days";
+				$str = " +" . ( $first_day_of_week - 1 ) . " days";
 			}
 			return $str;
 		}

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -46,7 +46,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		private $settings;
 
 		/**
-		 * Setup the Extension's properties.
+		 * Set up the Extension's properties.
 		 *
 		 * This always executes even if the required plugins are not present.
 		 */
@@ -102,7 +102,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 
 			add_filter( 'tribe_the_day_link', [ $this, 'filter_day_link' ] );
 			add_action( 'tribe_template_after_include:events/v2/day/top-bar/datepicker', [ $this, 'daystrip' ], 10, 3 );
-			add_action('wp_enqueue_scripts', [ $this, 'enquque_daystrip_styles'] );
+			add_action('wp_enqueue_scripts', [ $this, 'enqueue_daystrip_styles' ] );
 			add_action( 'wp_footer', [ $this, 'footer_styles' ] );
 
 			/**
@@ -166,7 +166,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 				$meets_req = false;
 			}
 
-			// Notice, if should be shown.
+			// Show notice, if it should be shown.
 			if ( ! $meets_req && is_admin() && current_user_can( 'activate_plugins' ) ) {
 				if ( 1 === $view_required_version ) {
 					$view_name = _x( 'Legacy Views', 'name of view', 'tribe-ext-daystrip' );
@@ -238,7 +238,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		/**
 		 * Enqueuing stylesheet
 		 */
-		public function enquque_daystrip_styles() {
+		public function enqueue_daystrip_styles() {
 			wp_enqueue_style( 'tribe-ext-daystrip', plugin_dir_url( __FILE__ ) . 'src/resources/style.css' );
 		}
 
@@ -331,7 +331,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 							2 ) . ' days' ) );
 			}
 
-			// Creating and filling the array of days that we show
+			// Creating and filling up the array of days that we show
 			$args['days'] = [];
 			for ( $i = 0; $i < $args['days_to_show']; $i++ ) {
 				$args['days'][] = date( 'Y-m-d', strtotime( $args['starting_date'] . ' +' . $i . ' days' ) );
@@ -355,8 +355,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		 * @return string|string[]
 		 */
 		function filter_day_link( $html ) {
-			$html = str_replace( 'rel="prev"', 'data-js="tribe-events-view-link"', $html );
-			return $html;
+			return str_replace( 'rel="prev"', 'data-js="tribe-events-view-link"', $html );
 		}
 
 		/**
@@ -365,7 +364,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		 * @param $start_date
 		 * @param $end_date
 		 *
-		 * @return mixed
+		 * @return array The events starting within the given timeframe.
 		 */
 		function get_events_for_timeframe( $start_date, $end_date ) {
 			$args   = [

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -503,19 +503,22 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 				$html .= '</span>';
 
 				// Date of day
-				if ( ! empty( $args['options']['date_format'] ) && $args['options']['date_format'] != '0' ) {
+				$date_format = $args['options']['date_format'] ?? 'j';
+				if ( $date_format != '0' ) {
 					$html .= '<span class="tribe-daystrip-date">';
-					$html .= $date->format( $args['options']['date_format'] );
+					$html .= $date->format( $date_format );
 					$html .= '</span>';
 				}
-				if ( ! empty( $args['options']['month_format'] ) && $args['options']['month_format'] != '0' ) {
+				$month_format = $args['options']['month_format'] ?? 'M';
+				if ( $month_format != '0' ) {
 					$html .= '<span class="tribe-daystrip-month">';
-					$html .= $date->format( $args['options']['month_format'] );
+					$html .= $date->format( $month_format );
 					$html .= '</span>';
 				}
 
 				// Day has event marker
-				if ( isset( $args['options']['hide_event_marker'] ) && ! $args['options']['hide_event_marker'] ) {
+				$hide_event_marker = $args['options']['hide_event_marker'] ?? false;
+				if ( ! $hide_event_marker ) {
 					if ( in_array( $day, $args['event_dates'] ) ) {
 						$html .= '<em
 								class="tribe-events-calendar-day__daystrip-events-icon--event"

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/daystrip/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-daystrip
  * Description:       Adds a day-by-day navigation strip at the top of the Day View.
- * Version:           1.0.1
+ * Version:           1.1.0
  * Extension Class:   Tribe\Extensions\Daystrip\Main
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -431,8 +431,8 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		 * Add dynamically calculated styles to the footer.
 		 */
 		public function footer_styles() {
-			$divider = $this->get_option( 'number_of_days' );
-			$behavior = $this->get_option( 'behavior' );
+			$divider = $this->get_option( 'number_of_days', 7 );
+			$behavior = $this->get_option( 'behavior', 'current_week' );
 
 			if ( $behavior == 'current_week' || $behavior == 'next_week' ) {
 				$divider = 7;


### PR DESCRIPTION
[TEC-4975](https://stellarwp.atlassian.net/browse/TEC-4975)
(Used the wrong ticket ID for the branch name. 🤦 )

The extension had several issues mostly coming from missing default values.

* Fix - Make sure that all options have a default value so that the extension can be used right after activation.
* Fix - Now the day and month names show up on the day-to-day navigation bar from the start.
* Fix - The event marker now properly shows up on days with events. [EXT-311]
* Tweak - There is now no warning message when saving the settings with an empty Start Date field.