### PR TITLE
Fix string divisor issue and bump to new major version.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,10 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
+= [1.1.0] TBD =
+
+* Fix - Correct an issue where a divisor could be a non-integer, resulting in an error. [TEC-4975]
+
 = [1.0.1] 2021-04-14 =
 
 * Fix - Adjusted the template directory to the correct one.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar
 Requires at least: 5.0
 Tested up to: 5.7
 Requires PHP: 7.0
-Stable tag: 1.0.1
+Stable tag: 2.0.0
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -29,11 +29,20 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
+== Upgrade Notice ==
+= [2.0] =
+
+Please see the changelog for the complete list of changes in this release.
+This extension is no longer compatible with versions of The Events Calendar prior to 6.0.
+Remember to always make a backup of your database and files before updating!
+
 == Changelog ==
 
-= [1.1.0] TBD =
+= [2.0.0] TBD =
 
+* Version - This and future versions of the extension require TEC 6.0. It is no longer compatible with the legacy views.
 * Fix - Correct an issue where a divisor could be a non-integer, resulting in an error. [TEC-4975]
+* Deprecated - Deprecated `enquque_daystrip_styles()` for `enqueue_daystrip_styles()` to correct a spelling error.
 
 = [1.0.1] 2021-04-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: theeventscalendar
 Donate link: https://evnt.is/29
 Tags: events, calendar
 Requires at least: 5.0
-Tested up to: 5.7
-Requires PHP: 7.0
-Stable tag: 1.0.1
+Tested up to: 6.3.2
+Requires PHP: 7.4
+Stable tag: 1.1.0
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -30,6 +30,12 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.1.0] 2023-11-06 =
+
+* Fix - Make sure that all options have a default value, so the extension can be used right after activation.
+* Fix - Now the day and month names show up on the day-to-day navigation bar from the start.
+* Fix - The event marker now properly shows up on days with events.
 
 = [1.0.1] 2021-04-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 * Fix - Make sure that all options have a default value, so the extension can be used right after activation.
 * Fix - Now the day and month names show up on the day-to-day navigation bar from the start.
 * Fix - The event marker now properly shows up on days with events.
+* Tweak - There is now no warning message when saving the settings with an empty Start Date field.
 
 = [1.0.1] 2021-04-14 =
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -228,6 +228,7 @@ if ( ! class_exists( Settings::class ) ) {
 					'tooltip'         => sprintf( esc_html__( "Use YYYY-MM-DD format. Works only with the option '%sShow fixed number of days starting on a specific date%s'.", 'tribe-ext-daystrip' ), '<em>', '</em>' ) . '<br/><em>' . esc_html__( 'Default value:', 'tribe-ext-daystrip') . ' 2</em>',
 					'validation_type' => 'alpha_numeric_with_dashes_and_underscores',
 					'size'            => 'medium',
+					'can_be_empty'    => true,
 				],
 				'length_of_day_name' => [
 					'type'            => 'text',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -2,7 +2,9 @@
 
 namespace Tribe\Extensions\Daystrip;
 
+use Codeception\Test\Interfaces\Dependent;
 use Tribe__Settings_Manager;
+use Tribe__Field_Conditional;
 
 if ( ! class_exists( Settings::class ) ) {
 	/**
@@ -195,7 +197,7 @@ if ( ! class_exists( Settings::class ) ) {
 		 */
 		public function add_settings() {
 			$fields = [
-				'Example'   => [
+				'day_strip_ext_header'   => [
 					'type' => 'html',
 					'html' => $this->get_example_intro_text(),
 				],
@@ -223,11 +225,17 @@ if ( ! class_exists( Settings::class ) ) {
 					'options'         => $this->behavior_options(),
 				],
 				'start_date' => [
-					'type'            => 'text',
-					'label'           => esc_html__( 'Start date', 'tribe-ext-daystrip' ),
-					'tooltip'         => sprintf( esc_html__( "Use YYYY-MM-DD format. Works only with the option '%sShow fixed number of days starting on a specific date%s'.", 'tribe-ext-daystrip' ), '<em>', '</em>' ) . '<br/><em>' . esc_html__( 'Default value:', 'tribe-ext-daystrip') . ' 2</em>',
-					'validation_type' => 'alpha_numeric_with_dashes_and_underscores',
-					'size'            => 'medium',
+					'type'                => 'text',
+					'label'               => esc_html__( 'Start date', 'tribe-ext-daystrip' ),
+					'tooltip'             => sprintf( esc_html__( "Use YYYY-MM-DD format. Works only with the option '%sShow fixed number of days starting on a specific date%s'.", 'tribe-ext-daystrip' ), '<em>', '</em>' ) . '<br/><em>' . esc_html__( 'Default value:', 'tribe-ext-daystrip') . ' 2</em>',
+					'validation_type'     => 'alpha_numeric_with_dashes_and_underscores',
+					'validate_if'         => new Tribe__Field_Conditional( 'behavior', 'fixed_from_date' ),
+					'size'                => 'medium',
+					'class'               => 'tribe-dependent',
+					'fieldset_attributes' => [
+						'data-depends'   => '#tribe_ext_daystrip_behavior-select',
+						'data-condition' => 'fixed_from_date',
+					],
 				],
 				'length_of_day_name' => [
 					'type'            => 'text',
@@ -237,7 +245,7 @@ if ( ! class_exists( Settings::class ) ) {
 					'size'            => 'small',
 					'default'         => 2,
 				],
-				'just_a_label' => [
+				'date_format_label' => [
 					'type'            => 'html',
 					'html' => '<p>'
 					          . sprintf(
@@ -249,20 +257,21 @@ if ( ! class_exists( Settings::class ) ) {
 				'date_format' => [
 					'type'            => 'text',
 					'label'           => esc_html__( 'Date format', 'tribe-ext-daystrip' ),
-					'tooltip'         => sprintf( esc_html__( 'Examples: %1$s - 1, %2$s - 01, %3$s - 1st, %4$s - hide', 'tribe-ext-daystrip' ),
+					'tooltip'         => sprintf( esc_html__( 'Examples: %1$s - "1", %2$s - "01", %3$s - "1st", %4$s (or empty) - hide', 'tribe-ext-daystrip' ),
 					                              '<code>j</code>',
 					                              '<code>d</code>',
 					                              '<code>jS</code>',
 					                              '<code>0</code>',
 					),
 					'validation_type' => 'alpha_numeric',
+					'can_be_empty'    => true,
 					'size'            => 'small',
 					'default'         => 'j',
 				],
 				'month_format' => [
 					'type'            => 'text',
 					'label'           => esc_html__( 'Month format', 'tribe-ext-daystrip' ),
-					'tooltip'         => sprintf( esc_html__( 'Examples: %1$s - Jan., %2$s - January, %3$s - 01, %4$s - 1, %5$s - hide', 'tribe-ext-daystrip' ),
+					'tooltip'         => sprintf( esc_html__( 'Examples: %1$s - "Jan", %2$s - "January", %3$s - "01", %4$s - "1", %5$s (or empty) - hide', 'tribe-ext-daystrip' ),
 					                              '<code>M</code>',
 					                              '<code>F</code>',
 					                              '<code>m</code>',
@@ -270,6 +279,7 @@ if ( ! class_exists( Settings::class ) ) {
 					                              '<code>0</code>',
 					),
 					'validation_type' => 'alpha_numeric',
+					'can_be_empty'    => true,
 					'size'            => 'small',
 					'default'         => 'M',
 				],
@@ -284,8 +294,8 @@ if ( ! class_exists( Settings::class ) ) {
 			$this->settings_helper->add_fields(
 				$this->prefix_settings_field_keys( $fields ),
 				'display',
-				'tribeEventsDateFormatSettingsTitle',
-				true
+				'embedGoogleMapsZoom',
+				false
 			);
 		}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -272,7 +272,7 @@ if ( ! class_exists( Settings::class ) ) {
 				'month_format' => [
 					'type'            => 'text',
 					'label'           => esc_html__( 'Month format', 'tribe-ext-daystrip' ),
-					'tooltip'         => sprintf( esc_html__( 'Examples: %1$s - "Jan", %2$s - "January", %3$s - "01", %4$s - "1", %5$s (or empty) - hide', 'tribe-ext-daystrip' ),
+					'tooltip'         => sprintf( esc_html__( 'Examples: %1$s - "Jan.", %2$s - "January", %3$s - "01", %4$s - "1", %5$s (or empty) - hide', 'tribe-ext-daystrip' ),
 					                              '<code>M</code>',
 					                              '<code>F</code>',
 					                              '<code>m</code>',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -197,7 +197,7 @@ if ( ! class_exists( Settings::class ) ) {
 			$fields = [
 				'Example'   => [
 					'type' => 'html',
-					'html' => $this->get_example_intro_text(),
+					'html' => $this->get_daystrip_intro_text(),
 				],
 				'full_width' => [
 					'type'            => 'checkbox_bool',
@@ -325,8 +325,8 @@ if ( ! class_exists( Settings::class ) ) {
 		 *
 		 * @return string
 		 */
-		private function get_example_intro_text() {
-			return '<h3>' . esc_html_x( 'Day Strip Extension Settings', 'Settings header', 'tribe-ext-daystrip' ) . '</h3>';
+		private function get_daystrip_intro_text() {
+			return '<h3 id="tec-settings-events-settings-display-daystrip">' . esc_html_x( 'Day Strip Extension Settings', 'Settings header', 'tribe-ext-daystrip' ) . '</h3>';
 		}
 
 	} // class

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -1,44 +1,41 @@
-.tribe-events-header .tribe-daystrip-container {
+.tribe-events-header .tribe-daystrip__container {
     display: none;
 }
-.tribe-events-header .tribe-daystrip-container.full-width {
+.tribe-events-header .tribe-daystrip__container--full-width {
     width: 100%;
     margin-top: 1em;
 }
-.tribe-common--breakpoint-medium.tribe-common .tribe-events-header .tribe-daystrip-container {
+.tribe-common--breakpoint-medium.tribe-common .tribe-events-header .tribe-daystrip__container {
     line-height: 1.1;
     display: flex;
     flex: auto;
     justify-content: space-between;
 }
-.tribe-events-header .tribe-daystrip-container .tribe-daystrip-day {
+.tribe-events-header .tribe-daystrip__container .tribe-daystrip__day {
     text-align: center;
     padding: 10px 5px;
     word-wrap: normal;
     flex-grow: 1;
 }
-.tribe-events-header .tribe-daystrip-container .tribe-daystrip-day:nth-child(n+2) {
+.tribe-events-header .tribe-daystrip__container .tribe-daystrip__day:nth-child(n+2) {
     border-left: 1px solid #d5d5d5;
 }
-.tribe-daystrip-day span {
+.tribe-daystrip__day span {
     display: block;
     text-align: center;
 }
-.tribe-daystrip-dayname {
+.tribe-daystrip__day-name {
     font-size: 0.7em;
     overflow: hidden;
     text-transform: uppercase;
 }
-.tribe-daystrip-date {
-
-}
-.tribe-events-header .tribe-daystrip-day.tribe-daystrip-past a {
+.tribe-events-header .tribe-daystrip__day--past a {
     color: #898b93;
 }
-.tribe-daystrip-day.tribe-daystrip-current {
+.tribe-daystrip__day--current {
     background-color: #eee;
 }
-.tribe-daystrip-day.tribe-daystrip-today {
+.tribe-daystrip__day--today {
     font-weight: bold;
 }
 .tribe-events .tribe-events-calendar-day__daystrip-events-icon--event {

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -18,7 +18,7 @@
     flex-grow: 1;
 }
 .tribe-events-header .tribe-daystrip__container .tribe-daystrip__day:nth-child(n+2) {
-    border-left: 1px solid #d5d5d5;
+    border-left: 1px solid car(--tec-color-border-default);
 }
 .tribe-daystrip__day span {
     display: block;
@@ -30,17 +30,17 @@
     text-transform: uppercase;
 }
 .tribe-events-header .tribe-daystrip__day--past a {
-    color: #898b93;
+    color: var(--tec-color-text-primary-light);
 }
 .tribe-daystrip__day--current {
-    background-color: #eee;
+    background-color: var(--tec-color-background-secondary);
 }
 .tribe-daystrip__day--today {
     font-weight: bold;
 }
 .tribe-events .tribe-events-calendar-day__daystrip-events-icon--event {
     display: inline-block;
-    background-color: #334aff;
+    background-color: var(--tec-color-accent-primary);
     border-radius: 50%;
     height: 8px;
     width: 8px;

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -9,13 +9,13 @@
     line-height: 1.1;
     display: flex;
     flex: auto;
-    /*justify-content: space-between;*/
+    justify-content: space-between;
 }
 .tribe-events-header .tribe-daystrip-container .tribe-daystrip-day {
     text-align: center;
     padding: 10px 5px;
     word-wrap: normal;
-    /*flex-grow: 1;*/
+    flex-grow: 1;
 }
 .tribe-events-header .tribe-daystrip-container .tribe-daystrip-day:nth-child(n+2) {
     border-left: 1px solid #d5d5d5;

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -131,7 +131,7 @@ class Main extends Tribe__Extension {
 
 		add_filter( 'tribe_the_day_link', [ $this, 'filter_day_link' ] );
 		add_action( 'tribe_template_after_include:events/v2/day/top-bar/datepicker', [ $this, 'daystrip' ], 10, 3 );
-		add_action('wp_enqueue_scripts', [ $this, 'enqueue_daystrip_styles'] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_daystrip_styles' ] );
 		add_action( 'wp_footer', [ $this, 'footer_styles' ] );
 
 		/**
@@ -323,7 +323,7 @@ class Main extends Tribe__Extension {
 				 *
 				 * @TODO Needs fixing
 				 */
-				$args['start_date'] = date('Y-m-d', strtotime('next week' . $this->adjust_week_start() ) );
+				$args['start_date'] = date( 'Y-m-d', strtotime( 'next week' . $this->adjust_week_start() ) );
 				$args['number_of_days'] = 7;
 
 				break;

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -240,7 +240,7 @@ class Main extends Tribe__Extension {
 		$args = [
 			'behavior'            => 'default',
 			'container_classes'   => [
-				'tribe-daystrip-container',
+				'tribe-daystrip__container',
 				'tribe-common-b2',
 			],
 			'date_format'         => 'j',
@@ -269,7 +269,7 @@ class Main extends Tribe__Extension {
 
 		// If full width add the necessary CSS class.
 		if ( (bool) $args['full_width'] ) {
-			$args['container_classes'][] = 'full-width';
+			$args['container_classes'][] = 'tribe-daystrip__container--full-width';
 		}
 
 		// Check the selected date, or today if nothing selected.
@@ -396,10 +396,10 @@ class Main extends Tribe__Extension {
 	 * @return string
 	 */
 	public function adjust_week_start() {
-		$first_day_of_week = get_option( 'start_of_week', 1 );
+		$first_day_of_week = absint( get_option( 'start_of_week', 1 ) );
 		$str = '';
 		// If it's Sunday (0)
-		if ( $first_day_of_week == 0 ) {
+		if ( $first_day_of_week === 0 ) {
 			$str = ' -1 day';
 		}
 		// If Tuesday (2) to Saturday (6)
@@ -443,14 +443,14 @@ class Main extends Tribe__Extension {
 		$behavior = $this->get_option( 'behavior', 'default' );
 
 		// Force divider to 7 if behavior is current or next week.
-		if ( $behavior == 'current_week' || $behavior == 'next_week' ) {
+		if ( $behavior === 'current_week' || $behavior === 'next_week' ) {
 			$divider = 7;
 		}
 
 		$cell_width = 100 / absint( $divider );
 
 		sprintf(
-			'%1$s .tribe-events-header .tribe-daystrip-container .tribe-daystrip-day { width: %2$d%%; } %3$s',
+			'%1$s .tribe-events-header .tribe-daystrip__container .tribe-daystrip__day { width: %2$d%%; } %3$s',
 			'<style id="tribe-ext-daystrip-styles">',
 			$cell_width,
 			'</style>'
@@ -474,19 +474,19 @@ class Main extends Tribe__Extension {
 			$date = date_create( $day );
 
 			$day_classes = [];
-			$day_classes[] = 'tribe-daystrip-day';
+			$day_classes[] = 'tribe-daystrip__day';
 
 			// Setting class for past, today, and future events
 			if ( strtotime( $day ) < strtotime( $args['todays_date'] ) ) {
-				$day_classes[] = 'tribe-daystrip-past';
-			} elseif ( strtotime( $day ) == strtotime( $args['todays_date'] ) ) {
-				$day_classes[] = 'tribe-daystrip-today';
+				$day_classes[] = 'tribe-daystrip__day--past';
+			} elseif ( strtotime( $day ) === strtotime( $args['todays_date'] ) ) {
+				$day_classes[] = 'tribe-daystrip__day--today';
 			} elseif ( strtotime( $day ) > strtotime( $args['todays_date'] ) ) {
-				$day_classes[] = 'tribe-daystrip-future';
+				$day_classes[] = 'tribe-daystrip__future';
 			}
 			// Setting class for selected day.
-			if ( strtotime( $day ) == strtotime( $args['selected_date_value'] ) ) {
-				$day_classes[] = 'tribe-daystrip-current';
+			if ( strtotime( $day ) === strtotime( $args['selected_date_value'] ) ) {
+				$day_classes[] = 'tribe-daystrip__day--current';
 			}
 
 			if ( in_array( $day, $args['event_dates'] ) ) {
@@ -502,7 +502,7 @@ class Main extends Tribe__Extension {
 			$html .= '<a href="' . tribe_events_get_url() . $day . '" data-js="tribe-events-view-link" aria-label="' . date( tribe_get_date_format( true ), strtotime( $day ) ) . '" title="' . date( tribe_get_date_format( true ), strtotime( $day ) ) . '">';
 
 			// Text part of the URL
-			$html .= '<span class="tribe-daystrip-dayname">';
+			$html .= '<span class="tribe-daystrip__day-name">';
 
 			// Name of day.
 			if ( (int) $args['length_of_day_name'] < 0 ) {
@@ -515,13 +515,13 @@ class Main extends Tribe__Extension {
 
 			// Date of day
 			if ( ! empty( $args['date_format'] ) ) {
-				$html .= '<span class="tribe-daystrip-date">';
+				$html .= '<span class="tribe-daystrip__date">';
 				$html .= $date->format( $args['date_format'] );
 				$html .= '</span>';
 			}
 
 			if ( ! empty( $args['month_format'] ) ) {
-				$html .= '<span class="tribe-daystrip-month">';
+				$html .= '<span class="tribe-daystrip__month">';
 				$html .= $date->format( $args['month_format'] );
 				$html .= '</span>';
 			}

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -116,18 +116,8 @@ class Main extends Tribe__Extension {
 			return;
 		}
 
-		// Don't run on legacy views
-		if (
-			! function_exists( 'tribe_events_views_v2_is_enabled' )
-			|| empty( tribe_events_views_v2_is_enabled() )
-		) {
-			return;
-		}
-
 		$this->class_loader();
-
 		$this->get_settings();
-
 
 		add_filter( 'tribe_the_day_link', [ $this, 'filter_day_link' ] );
 		add_action( 'tribe_template_after_include:events/v2/day/top-bar/datepicker', [ $this, 'daystrip' ], 10, 3 );

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -302,7 +302,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 				} // Fixed time range from set date
 				elseif ( $options['behavior'] == 'fixed_from_date' ) {
 					$start_date = $options['start_date'] ?? $args['todays_date'];
-					$sd = explode( '-', $start_date );
+					$sd         = explode( '-', $start_date );
 					if ( checkdate( $sd[1], $sd[2], $sd[0] ) ) {
 						$args['starting_date'] = $start_date;
 					} else {
@@ -324,12 +324,11 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 					$args['starting_date'] = date( 'Y-m-d', strtotime( 'next week' . $this->adjust_week_start() ) );
 					$args['days_to_show']  = 7;
 				} // Default, selected day in the middle
-				else {
-					// Choosing the starting date for the array and formatting it
-					$args['starting_date'] = date( 'Y-m-d',
-						strtotime( $args['selected_date_value'] . ' -' . intdiv( $args['days_to_show'],
-								2 ) . ' days' ) );
-				}
+			} else {
+				// Choosing the starting date for the array and formatting it
+				$args['starting_date'] = date( 'Y-m-d',
+					strtotime( $args['selected_date_value'] . ' -' . intdiv( $args['days_to_show'],
+							2 ) . ' days' ) );
 			}
 
 			// Creating and filling the array of days that we show

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -380,7 +380,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 			$events = tribe_get_events( $args );
 
 			foreach ( $events as $event ) {
-				$d = date( 'Y-m-d', strtotime( $event->event_date ) );
+				$d = tribe_get_start_date( $event->ID, false, 'Y-m-d' );
 				if ( ! in_array( $d, $dates ) ) {
 					$dates[] = $d;
 				}
@@ -403,7 +403,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 			}
 			// If Tuesday (2) to Saturday (6)
 			elseif( $first_day_of_week > 1 ) {
-				$str = " +" . $first_day_of_week - 1 . " days";
+				$str = " +" . ( $first_day_of_week - 1 ) . " days";
 			}
 			return $str;
 		}

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -46,7 +46,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		private $settings;
 
 		/**
-		 * Setup the Extension's properties.
+		 * Set up the Extension's properties.
 		 *
 		 * This always executes even if the required plugins are not present.
 		 */
@@ -102,7 +102,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 
 			add_filter( 'tribe_the_day_link', [ $this, 'filter_day_link' ] );
 			add_action( 'tribe_template_after_include:events/v2/day/top-bar/datepicker', [ $this, 'daystrip' ], 10, 3 );
-			add_action('wp_enqueue_scripts', [ $this, 'enquque_daystrip_styles'] );
+			add_action('wp_enqueue_scripts', [ $this, 'enqueue_daystrip_styles' ] );
 			add_action( 'wp_footer', [ $this, 'footer_styles' ] );
 
 			/**
@@ -166,7 +166,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 				$meets_req = false;
 			}
 
-			// Notice, if should be shown.
+			// Show notice, if it should be shown.
 			if ( ! $meets_req && is_admin() && current_user_can( 'activate_plugins' ) ) {
 				if ( 1 === $view_required_version ) {
 					$view_name = _x( 'Legacy Views', 'name of view', 'tribe-ext-daystrip' );
@@ -238,7 +238,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		/**
 		 * Enqueuing stylesheet
 		 */
-		public function enquque_daystrip_styles() {
+		public function enqueue_daystrip_styles() {
 			wp_enqueue_style( 'tribe-ext-daystrip', plugin_dir_url( __FILE__ ) . 'src/resources/style.css' );
 		}
 
@@ -331,7 +331,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 							2 ) . ' days' ) );
 			}
 
-			// Creating and filling the array of days that we show
+			// Creating and filling up the array of days that we show
 			$args['days'] = [];
 			for ( $i = 0; $i < $args['days_to_show']; $i++ ) {
 				$args['days'][] = date( 'Y-m-d', strtotime( $args['starting_date'] . ' +' . $i . ' days' ) );
@@ -355,8 +355,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		 * @return string|string[]
 		 */
 		function filter_day_link( $html ) {
-			$html = str_replace( 'rel="prev"', 'data-js="tribe-events-view-link"', $html );
-			return $html;
+			return str_replace( 'rel="prev"', 'data-js="tribe-events-view-link"', $html );
 		}
 
 		/**
@@ -365,7 +364,7 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		 * @param $start_date
 		 * @param $end_date
 		 *
-		 * @return mixed
+		 * @return array The events starting within the given timeframe.
 		 */
 		function get_events_for_timeframe( $start_date, $end_date ) {
 			$args   = [

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -503,19 +503,22 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 				$html .= '</span>';
 
 				// Date of day
-				if ( ! empty( $args['options']['date_format'] ) && $args['options']['date_format'] != '0' ) {
+				$date_format = $args['options']['date_format'] ?? 'j';
+				if ( $date_format != '0' ) {
 					$html .= '<span class="tribe-daystrip-date">';
-					$html .= $date->format( $args['options']['date_format'] );
+					$html .= $date->format( $date_format );
 					$html .= '</span>';
 				}
-				if ( ! empty( $args['options']['month_format'] ) && $args['options']['month_format'] != '0' ) {
+				$month_format = $args['options']['month_format'] ?? 'M';
+				if ( $month_format != '0' ) {
 					$html .= '<span class="tribe-daystrip-month">';
-					$html .= $date->format( $args['options']['month_format'] );
+					$html .= $date->format( $month_format );
 					$html .= '</span>';
 				}
 
 				// Day has event marker
-				if ( isset( $args['options']['hide_event_marker'] ) && ! $args['options']['hide_event_marker'] ) {
+				$hide_event_marker = $args['options']['hide_event_marker'] ?? false;
+				if ( ! $hide_event_marker ) {
 					if ( in_array( $day, $args['event_dates'] ) ) {
 						$html .= '<em
 								class="tribe-events-calendar-day__daystrip-events-icon--event"

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/daystrip/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-daystrip
  * Description:       Adds a day-by-day navigation strip at the top of the Day View.
- * Version:           1.0.1
+ * Version:           1.1.0
  * Extension Class:   Tribe\Extensions\Daystrip\Main
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/daystrip/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-daystrip
  * Description:       Adds a day-by-day navigation strip at the top of the Day View.
- * Version:           1.0.1
+ * Version:           1.1.0
  * Extension Class:   Tribe\Extensions\Daystrip\Main
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971
@@ -28,510 +28,543 @@ namespace Tribe\Extensions\Daystrip;
 use Tribe__Autoloader;
 use Tribe__Extension;
 
-// Do not load unless Tribe Common is fully loaded and our class does not yet exist.
-if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
+if ( ! class_exists( 'Tribe__Extension', false ) ) {
+	return;
+}
+
+if ( class_exists( Main::class, false ) ) {
+	return;
+}
+
+/**
+ * Extension main class, class begins loading on init() function.
+ */
+class Main extends Tribe__Extension {
+
 	/**
-	 * Extension main class, class begins loading on init() function.
+	 * The TEC autoloader instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Tribe__Autoloader
 	 */
-	class Main extends Tribe__Extension {
+	private $class_loader;
 
-		/**
-		 * @var Tribe__Autoloader
-		 */
-		private $class_loader;
+	/**
+	 * The extension settings instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Settings
+	 */
+	private $settings;
 
-		/**
-		 * @var Settings
-		 */
-		private $settings;
+	/**
+	 * Setup the Extension's properties.
+	 *
+	 * This always executes even if the required plugins are not present.
+	 */
+	public function construct() {
+		$this->add_required_plugin( 'Tribe__Events__Main', '5.0' );
+	}
 
-		/**
-		 * Setup the Extension's properties.
-		 *
-		 * This always executes even if the required plugins are not present.
-		 */
-		public function construct() {
-			$this->add_required_plugin( 'Tribe__Events__Main', '5.0' );
+	/**
+	 * Get this plugin's options prefix.
+	 *
+	 * Settings_Helper will append a trailing underscore before each option.
+	 *
+	 * @return string
+	 * @see \Tribe\Extensions\Daystrip\Settings::set_options_prefix()
+	 *
+	 */
+	private function get_options_prefix() {
+		return (string) str_replace( '-', '_', 'tribe-ext-daystrip' );
+	}
+
+	/**
+	 * Get Settings instance.
+	 *
+	 * @return Settings
+	 */
+	private function get_settings() {
+		if ( empty( $this->settings ) ) {
+			$this->settings = new Settings( $this->get_options_prefix() );
 		}
 
-		/**
-		 * Get this plugin's options prefix.
-		 *
-		 * Settings_Helper will append a trailing underscore before each option.
-		 *
-		 * @return string
-		 * @see \Tribe\Extensions\Daystrip\Settings::set_options_prefix()
-		 *
-		 */
-		private function get_options_prefix() {
-			return (string) str_replace( '-', '_', 'tribe-ext-daystrip' );
+		return $this->settings;
+	}
+
+	/**
+	 * Extension initialization and hooks.
+	 */
+	public function init() {
+		// Load plugin textdomain
+		load_plugin_textdomain( 'tribe-ext-daystrip', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+
+		if ( ! $this->php_version_check() ) {
+			return;
 		}
 
+		if ( ! $this->is_using_compatible_view_version() ) {
+			return;
+		}
+
+		$this->class_loader();
+
+		$this->get_settings();
+
+
+		add_filter( 'tribe_the_day_link', [ $this, 'filter_day_link' ] );
+		add_action( 'tribe_template_after_include:events/v2/day/top-bar/datepicker', [ $this, 'daystrip' ], 10, 3 );
+		add_action('wp_enqueue_scripts', [ $this, 'enquque_daystrip_styles'] );
+		add_action( 'wp_footer', [ $this, 'footer_styles' ] );
+
 		/**
-		 * Get Settings instance.
-		 *
-		 * @return Settings
+		 * @TODO Leaving here for a later version
 		 */
-		private function get_settings() {
-			if ( empty( $this->settings ) ) {
-				$this->settings = new Settings( $this->get_options_prefix() );
+		//add_filter( 'tribe_events_views_v2_view_repository_args', [ $this, 'jump_to_next_week' ], 10, 3 );
+	}
+
+	/**
+	 * Check if we have a sufficient version of PHP. Admin notice if we don't and user should see it.
+	 *
+	 * @link https://theeventscalendar.com/knowledgebase/php-version-requirement-changes/ All extensions require PHP 5.6+.
+	 *
+	 * @return bool
+	 */
+	private function php_version_check() {
+		$php_required_version = '7.0';
+
+		if ( version_compare( PHP_VERSION, $php_required_version, '<' ) ) {
+			if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
+				$message = '<p>';
+				$message .= sprintf( __( '%s requires PHP version %s or newer to work. Please contact your website host and inquire about updating PHP.',
+											'tribe-ext-daystrip' ),
+										$this->get_name(),
+										$php_required_version );
+				$message .= sprintf( ' <a href="%1$s">%1$s</a>', 'https://wordpress.org/about/requirements/' );
+				$message .= '</p>';
+				tribe_notice( 'tribe-ext-daystrip-php-version', $message, [ 'type' => 'error' ] );
 			}
 
-			return $this->settings;
+			return false;
 		}
 
-		/**
-		 * Extension initialization and hooks.
-		 */
-		public function init() {
-			// Load plugin textdomain
-			load_plugin_textdomain( 'tribe-ext-daystrip', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+		return true;
+	}
 
-			if ( ! $this->php_version_check() ) {
-				return;
-			}
+	/**
+	 * Check if we have the required TEC view. Admin notice if we don't and user should see it.
+	 *
+	 * @return bool
+	 */
+	private function is_using_compatible_view_version() {
+		$view_required_version = 2;
 
-			if ( ! $this->is_using_compatible_view_version() ) {
-				return;
-			}
+		$meets_req = true;
 
-			$this->class_loader();
-
-			$this->get_settings();
-
-
-			add_filter( 'tribe_the_day_link', [ $this, 'filter_day_link' ] );
-			add_action( 'tribe_template_after_include:events/v2/day/top-bar/datepicker', [ $this, 'daystrip' ], 10, 3 );
-			add_action('wp_enqueue_scripts', [ $this, 'enquque_daystrip_styles'] );
-			add_action( 'wp_footer', [ $this, 'footer_styles' ] );
-
-			/**
-			 * @TODO Leaving here for a later version
-			 */
-			//add_filter( 'tribe_events_views_v2_view_repository_args', [ $this, 'jump_to_next_week' ], 10, 3 );
+		// Is V2 enabled?
+		if ( function_exists( 'tribe_events_views_v2_is_enabled' ) && ! empty( tribe_events_views_v2_is_enabled() ) ) {
+			$is_v2 = true;
+		} else {
+			$is_v2 = false;
 		}
 
-		/**
-		 * Check if we have a sufficient version of PHP. Admin notice if we don't and user should see it.
-		 *
-		 * @link https://theeventscalendar.com/knowledgebase/php-version-requirement-changes/ All extensions require PHP 5.6+.
-		 *
-		 * @return bool
-		 */
-		private function php_version_check() {
-			$php_required_version = '7.0';
-
-			if ( version_compare( PHP_VERSION, $php_required_version, '<' ) ) {
-				if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
-					$message = '<p>';
-					$message .= sprintf( __( '%s requires PHP version %s or newer to work. Please contact your website host and inquire about updating PHP.',
-					                         'tribe-ext-daystrip' ),
-					                     $this->get_name(),
-					                     $php_required_version );
-					$message .= sprintf( ' <a href="%1$s">%1$s</a>', 'https://wordpress.org/about/requirements/' );
-					$message .= '</p>';
-					tribe_notice( 'tribe-ext-daystrip-php-version', $message, [ 'type' => 'error' ] );
-				}
-
-				return false;
-			}
-
-			return true;
+		// V1 compatibility check.
+		if ( 1 === $view_required_version && $is_v2 ) {
+			$meets_req = false;
 		}
 
-		/**
-		 * Check if we have the required TEC view. Admin notice if we don't and user should see it.
-		 *
-		 * @return bool
-		 */
-		private function is_using_compatible_view_version() {
-			$view_required_version = 2;
+		// V2 compatibility check.
+		if ( 2 === $view_required_version && ! $is_v2 ) {
+			$meets_req = false;
+		}
 
-			$meets_req = true;
-
-			// Is V2 enabled?
-			if ( function_exists( 'tribe_events_views_v2_is_enabled' ) && ! empty( tribe_events_views_v2_is_enabled() ) ) {
-				$is_v2 = true;
+		// Notice, if should be shown.
+		if ( ! $meets_req && is_admin() && current_user_can( 'activate_plugins' ) ) {
+			if ( 1 === $view_required_version ) {
+				$view_name = _x( 'Legacy Views', 'name of view', 'tribe-ext-daystrip' );
 			} else {
-				$is_v2 = false;
+				$view_name = _x( 'Updated (V2) Views', 'name of view', 'tribe-ext-daystrip' );
 			}
 
-			// V1 compatibility check.
-			if ( 1 === $view_required_version && $is_v2 ) {
-				$meets_req = false;
-			}
-
-			// V2 compatibility check.
-			if ( 2 === $view_required_version && ! $is_v2 ) {
-				$meets_req = false;
-			}
-
-			// Notice, if should be shown.
-			if ( ! $meets_req && is_admin() && current_user_can( 'activate_plugins' ) ) {
-				if ( 1 === $view_required_version ) {
-					$view_name = _x( 'Legacy Views', 'name of view', 'tribe-ext-daystrip' );
-				} else {
-					$view_name = _x( 'Updated (V2) Views', 'name of view', 'tribe-ext-daystrip' );
-				}
-
-				$view_name = sprintf( '<a href="%s">%s</a>',
-				                      esc_url( admin_url( 'edit.php?page=tribe-common&tab=display&post_type=tribe_events' ) ),
-				                      $view_name );
-
-				// Translators: 1: Extension plugin name, 2: Name of required view, linked to Display tab.
-				$message = sprintf( __( '%1$s requires the "%2$s" so this extension\'s code will not run until this requirement is met. You may want to deactivate this extension or visit its homepage to see if there are any updates available.',
-				                        'tribe-ext-daystrip' ),
-				                    $this->get_name(),
-				                    $view_name );
-
-				tribe_notice( 'tribe-ext-daystrip-view-mismatch',
-				              '<p>' . $message . '</p>',
-				              [ 'type' => 'error' ] );
-			}
-
-			return $meets_req;
-		}
-
-		/**
-		 * Use Tribe Autoloader for all class files within this namespace in the 'src' directory.
-		 *
-		 * @return Tribe__Autoloader
-		 */
-		public function class_loader() {
-			if ( empty( $this->class_loader ) ) {
-				$this->class_loader = new Tribe__Autoloader;
-				$this->class_loader->set_dir_separator( '\\' );
-				$this->class_loader->register_prefix( __NAMESPACE__ . '\\',
-				                                      __DIR__ . DIRECTORY_SEPARATOR . 'src' );
-			}
-
-			$this->class_loader->register_autoloader();
-
-			return $this->class_loader;
-		}
-
-		/**
-		 * Get all of this extension's options.
-		 *
-		 * @return array
-		 */
-		public function get_all_options() {
-			$settings = $this->get_settings();
-
-			return $settings->get_all_options();
-		}
-
-		/**
-		 * Get a specific extension option.
-		 *
-		 * @param $option
-		 * @param string $default
-		 *
-		 * @return array
-		 */
-		public function get_option( $option, $default ='' ) {
-			$settings = $this->get_settings();
-
-			return $settings->get_option( $option, $default );
-		}
-
-		/**
-		 * Enqueuing stylesheet
-		 */
-		public function enquque_daystrip_styles() {
-			wp_enqueue_style( 'tribe-ext-daystrip', plugin_dir_url( __FILE__ ) . 'src/resources/style.css' );
-		}
-
-		/**
-		 * Compiles the data for the daystrip.
-		 *
-		 * @param $file
-		 * @param $name
-		 * @param $template
-		 */
-		public function daystrip( $file, $name, $template ) {
-			$options = $this->get_all_options();
-
-			// Some default values
-			$args = [
-				'days_to_show'        => 9,
-				'day_name_length'     => 2,
-				'full_width'          => '',
-				'todays_date'         => $template->get( 'today' ),
-				'selected_date_value' => '',
-				'starting_date'       => '',
-				'days'                => [],
-				'event_dates'         => [],
-				'container_classes'   => [
-					'tribe-daystrip-container',
-					'tribe-common-b2',
-				],
-				'day_classes'         => [],
-				'options'             => $options,
-			];
-
-			$args['days_to_show'] = (int) $options['number_of_days'];
-			// If out of range, then set to default
-			if ( $args['days_to_show'] < 3 || $args['days_to_show'] > 31 ) {
-				$args['days_to_show'] = 9;
-			}
-
-			$args['day_name_length'] = (int) $options['length_of_day_name'];
-
-			// If full width, add the necessary CSS class
-			if ( $options['full_width'] ) {
-				$args['container_classes'][] = 'full-width';
-			}
-
-			// Check the selected date, or today if nothing selected
-			$args['selected_date_value'] = $template->get( [ 'bar', 'date' ], $args['todays_date'] );
-			if ( empty( $args['selected_date_value'] ) ) {
-				$args['selected_date_value'] = $args['todays_date'];
-			}
-
-			// Fixed time range from today
-			if ( $options['behavior'] == 'fixed_from_today' ) {
-				$args['starting_date'] = $args['todays_date'];
-			}
-			// Fixed time range from set date
-			elseif ( $options['behavior'] == 'fixed_from_date' ) {
-				$sd = explode( '-', $options['start_date'] );
-				if ( checkdate( $sd[1], $sd[2], $sd[0] ) ) {
-					$args['starting_date'] = $options['start_date'];
-				}
-				else {
-					$args['starting_date'] = $args['todays_date'];
-				}
-			}
-			// Only show forward
-			elseif ( $options['behavior'] == 'forward' ) {
-				$args['starting_date'] = $args['selected_date_value'];
-			}
-			// Current week
-			elseif ( $options['behavior'] == 'current_week' ) {
-				$args['starting_date'] = date('Y-m-d', strtotime('this week' . $this->adjust_week_start() ) );
-				$args['days_to_show'] = 7;
-			}
-			/**
-			 * Next week
-			 *
-			 * @TODO Needs fixing
-			 */
-			elseif ( $options['behavior'] == 'next_week' ) {
-				$args['starting_date'] = date('Y-m-d', strtotime('next week' . $this->adjust_week_start() ) );
-				$args['days_to_show'] = 7;
-			}
-			// Default, selected day in the middle
-			else {
-				// Choosing the starting date for the array and formatting it
-				$args['starting_date'] = date( 'Y-m-d',
-				                               strtotime( $args['selected_date_value'] . ' -' . intdiv( $args['days_to_show'],
-				                                                                                        2 ) . ' days' ) );
-			}
-
-			// Creating and filling the array of days that we show
-			$args['days'] = [];
-			for ( $i = 0; $i < $args['days_to_show']; $i++ ) {
-				$args['days'][] = date( 'Y-m-d', strtotime( $args['starting_date'] . ' +' . $i . ' days' ) );
-			}
-
-			// Dates on which we have events
-			// The end date is excluded, so we need to add one day to the end
-			$args['event_dates'] = $this->get_events_for_timeframe(
-				$args['days'][0],
-				date( 'Y-m-d', strtotime( end( $args['days'] ) . '+1 day' ) )
+			$view_name = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( admin_url( 'edit.php?page=tribe-common&tab=display&post_type=tribe_events' ) ),
+				$view_name
 			);
 
-			$this->render_daystrip( $args );
+			// Translators: 1: Extension plugin name, 2: Name of required view, linked to Display tab.
+			$message = sprintf(
+				__(
+					'%1$s requires the "%2$s" so this extension\'s code will not run until this requirement is met. You may want to deactivate this extension or visit its homepage to see if there are any updates available.',
+					'tribe-ext-daystrip'
+				),
+				$this->get_name(),
+				$view_name
+			);
+
+			tribe_notice( 'tribe-ext-daystrip-view-mismatch',
+							'<p>' . $message . '</p>',
+							[ 'type' => 'error' ] );
 		}
 
-		/**
-		 * Filters the URL to make it work with AJAX loading.
-		 *
-		 * @param $html
-		 *
-		 * @return string|string[]
-		 */
-		function filter_day_link( $html ) {
-			$html = str_replace( 'rel="prev"', 'data-js="tribe-events-view-link"', $html );
-			return $html;
+		return $meets_req;
+	}
+
+	/**
+	 * Use Tribe Autoloader for all class files within this namespace in the 'src' directory.
+	 *
+	 * @return Tribe__Autoloader
+	 */
+	public function class_loader() {
+		if ( empty( $this->class_loader ) ) {
+			$this->class_loader = new Tribe__Autoloader;
+			$this->class_loader->set_dir_separator( '\\' );
+			$this->class_loader->register_prefix( __NAMESPACE__ . '\\', __DIR__ . DIRECTORY_SEPARATOR . 'src' );
 		}
 
+		$this->class_loader->register_autoloader();
+
+		return $this->class_loader;
+	}
+
+	/**
+	 * Get all of this extension's options.
+	 *
+	 * @return array
+	 */
+	public function get_all_options() {
+		$settings = $this->get_settings();
+
+		return $settings->get_all_options();
+	}
+
+	/**
+	 * Get a specific extension option.
+	 *
+	 * @param $option
+	 * @param string $default
+	 *
+	 * @return array
+	 */
+	public function get_option( $option, $default ='' ) {
+		$settings = $this->get_settings();
+
+		return $settings->get_option( $option, $default );
+	}
+
+	/**
+	 * Enqueuing stylesheet.
+	 *
+	 * @since 1.0.0
+	 * @deprecated 1.1.0 Fix typo in method name.
+	 */
+	public function enquque_daystrip_styles() {
+		_deprecated_function( __METHOD__, '1.1.0', 'enqueue_daystrip_styles' );
+
+		return $this->enqueue_daystrip_styles();
+	}
+
+	/**
+	 * Enqueuing stylesheet.
+	 *
+	 * @since 1.1.0
+	 */
+	public function enqueue_daystrip_styles() {
+		wp_enqueue_style( 'tribe-ext-daystrip', plugin_dir_url( __FILE__ ) . 'src/resources/style.css' );
+	}
+
+	/**
+	 * Compiles the data for the daystrip.
+	 *
+	 * @param $file
+	 * @param $name
+	 * @param $template
+	 */
+	public function daystrip( $file, $name, $template ) {
+		$options = $this->get_all_options();
+
+		// Some default values
+		$args = [
+			'days_to_show'        => 9,
+			'day_name_length'     => 2,
+			'full_width'          => '',
+			'todays_date'         => $template->get( 'today' ),
+			'selected_date_value' => '',
+			'starting_date'       => '',
+			'days'                => [],
+			'event_dates'         => [],
+			'day_classes'         => [],
+			'options'             => $options,
+			'container_classes'   => [
+				'tribe-daystrip-container',
+				'tribe-common-b2',
+			],
+		];
+
+		$args['days_to_show'] = (int) $options['number_of_days'];
+		// If out of range, then set to default
+		if ( $args['days_to_show'] < 3 || $args['days_to_show'] > 31 ) {
+			$args['days_to_show'] = 9;
+		}
+
+		$args['day_name_length'] = (int) $options['length_of_day_name'];
+
+		// If full width, add the necessary CSS class.
+		if ( $options['full_width'] ) {
+			$args['container_classes'][] = 'full-width';
+		}
+
+		// Check the selected date, or today if nothing selected.
+		$args['selected_date_value'] = $template->get( [ 'bar', 'date' ], $args['todays_date'] );
+		if ( empty( $args['selected_date_value'] ) ) {
+			$args['selected_date_value'] = $args['todays_date'];
+		}
+
+		// Fixed time range from today
+		if ( $options['behavior'] == 'fixed_from_today' ) {
+			$args['starting_date'] = $args['todays_date'];
+		}
+		// Fixed time range from set date
+		elseif ( $options['behavior'] == 'fixed_from_date' ) {
+			$sd = explode( '-', $options['start_date'] );
+			if ( checkdate( $sd[1], $sd[2], $sd[0] ) ) {
+				$args['starting_date'] = $options['start_date'];
+			}
+			else {
+				$args['starting_date'] = $args['todays_date'];
+			}
+		}
+		// Only show forward
+		elseif ( $options['behavior'] == 'forward' ) {
+			$args['starting_date'] = $args['selected_date_value'];
+		}
+		// Current week
+		elseif ( $options['behavior'] == 'current_week' ) {
+			$args['starting_date'] = date('Y-m-d', strtotime('this week' . $this->adjust_week_start() ) );
+			$args['days_to_show'] = 7;
+		}
 		/**
-		 * Get the dates of events in the timeframe shown on the day strip.
+		 * Next week
 		 *
-		 * @param $start_date
-		 * @param $end_date
-		 *
-		 * @return mixed
+		 * @TODO Needs fixing
 		 */
-		function get_events_for_timeframe( $start_date, $end_date ) {
-			$args   = [
-				'start_date'   => $start_date,
-				'end_date'     => $end_date,
-				'posts_per_page'  => -1,
-			];
-			$dates =  [];
+		elseif ( $options['behavior'] == 'next_week' ) {
+			$args['starting_date'] = date('Y-m-d', strtotime('next week' . $this->adjust_week_start() ) );
+			$args['days_to_show'] = 7;
+		}
+		// Default, selected day in the middle
+		else {
+			// Choosing the starting date for the array and formatting it
+			$args['starting_date'] = date( 'Y-m-d',
+											strtotime( $args['selected_date_value'] . ' -' . intdiv( $args['days_to_show'],
+																									2 ) . ' days' ) );
+		}
 
-			// This only brings 'Post per page' number of events
-			$events = tribe_get_events( $args );
+		// Creating and filling the array of days that we show
+		$args['days'] = [];
+		for ( $i = 0; $i < $args['days_to_show']; $i++ ) {
+			$args['days'][] = date( 'Y-m-d', strtotime( $args['starting_date'] . ' +' . $i . ' days' ) );
+		}
 
-			foreach ( $events as $event ) {
-				$d = date( 'Y-m-d', strtotime( $event->event_date ) );
-				if ( ! in_array( $d, $dates ) ) {
-					$dates[] = $d;
-				}
+		// Dates on which we have events
+		// The end date is excluded, so we need to add one day to the end
+		$args['event_dates'] = $this->get_events_for_timeframe(
+			$args['days'][0],
+			date( 'Y-m-d', strtotime( end( $args['days'] ) . '+1 day' ) )
+		);
+
+		$this->render_daystrip( $args );
+	}
+
+	/**
+	 * Filters the URL to make it work with AJAX loading.
+	 *
+	 * @param $html
+	 *
+	 * @return string|string[]
+	 */
+	function filter_day_link( $html ) {
+		$html = str_replace( 'rel="prev"', 'data-js="tribe-events-view-link"', $html );
+		return $html;
+	}
+
+	/**
+	 * Get the dates of events in the timeframe shown on the day strip.
+	 *
+	 * @param $start_date
+	 * @param $end_date
+	 *
+	 * @return mixed
+	 */
+	function get_events_for_timeframe( $start_date, $end_date ) {
+		$args   = [
+			'start_date'   => $start_date,
+			'end_date'     => $end_date,
+			'posts_per_page'  => -1,
+		];
+		$dates =  [];
+
+		// This only brings 'Post per page' number of events
+		$events = tribe_get_events( $args );
+
+		foreach ( $events as $event ) {
+			$d = date( 'Y-m-d', strtotime( $event->event_date ) );
+			if ( ! in_array( $d, $dates ) ) {
+				$dates[] = $d;
+			}
+		}
+
+		return $dates;
+	}
+
+	/**
+	 * Adjust the start of the week based on the WordPress setting.
+	 *
+	 * @return string
+	 */
+	public function adjust_week_start() {
+		$first_day_of_week = get_option( 'start_of_week', 1 );
+		$str = '';
+		// If it's Sunday (0)
+		if ( $first_day_of_week == 0 ) {
+			$str = ' -1 day';
+		}
+		// If Tuesday (2) to Saturday (6)
+		elseif( $first_day_of_week > 1 ) {
+			$str = " +" . $first_day_of_week - 1 . " days";
+		}
+		return $str;
+	}
+
+	/**
+	 * Makes the day view jump to a specific date.
+	 *
+	 * @TODO Needs work
+	 *
+	 * @param $repository_args
+	 * @param $context
+	 * @param $view
+	 *
+	 * @return mixed
+	 */
+	function  jump_to_next_week( $repository_args, $context, $view )  {
+		$event_date = $context->get( 'event_date' );
+		//if ( ! $event_date ) {
+		if ( tribe_context()->get( 'view_request' ) === 'day' ) {
+			$context = $context->alter( [ 'event_date' => '2020-10-19' ] );
+			$view->set_context( $context );
+		}
+
+		return $repository_args;
+	}
+
+	/**
+	 * Add dynamically calculated styles to the footer.
+	 */
+	public function footer_styles() {
+		$divider  = $this->get_option( 'number_of_days', 9 );
+		$behavior = $this->get_option( 'behavior', 'default' );
+
+		// Force divider to 7 if behavior is current or next week.
+		if ( $behavior == 'current_week' || $behavior == 'next_week' ) {
+			$divider = 7;
+		}
+
+		$cell_width = 100 / absint( $divider );
+
+		sprintf(
+			'%1$s .tribe-events-header .tribe-daystrip-container .tribe-daystrip-day { width: %2$d%%; } %3$s',
+			'<style id="tribe-ext-daystrip-styles">',
+			$cell_width,
+			'</style>'
+		);
+	}
+
+	/**
+	 * Rendering the daystrip markup.
+	 *
+	 * @param array $args
+	 */
+	private function render_daystrip( array $args ) {
+
+		// Opening the strip
+		$html = '<div class="' . implode( " ", $args['container_classes'] ) . '">';
+
+		// Going through the array and setting up the strip
+		foreach ( $args['days'] as $day ) {
+			// Making a date object
+			$date = date_create( $day );
+
+			unset( $args['day_classes'] );
+			$args['day_classes'][] = 'tribe-daystrip-day';
+			// Setting class for past, today, and future events
+			if ( strtotime( $day ) < strtotime( $args['todays_date'] ) ) {
+				$args['day_classes'][] = 'tribe-daystrip-past';
+			} elseif ( strtotime( $day ) == strtotime( $args['todays_date'] ) ) {
+				$args['day_classes'][] = 'tribe-daystrip-today';
+			} elseif ( strtotime( $day ) > strtotime( $args['todays_date'] ) ) {
+				$args['day_classes'][] = 'tribe-daystrip-future';
+			}
+			// Setting class for selected day
+			if ( strtotime( $day ) == strtotime( $args['selected_date_value'] ) ) {
+				$args['day_classes'][] = 'tribe-daystrip-current';
 			}
 
-			return $dates;
-		}
-
-		/**
-		 * Adjust the start of the week based on the WordPress setting.
-		 *
-		 * @return string
-		 */
-		public function adjust_week_start() {
-			$first_day_of_week = get_option( 'start_of_week', 1 );
-			$str = '';
-			// If it's Sunday (0)
-			if ( $first_day_of_week == 0 ) {
-				$str = ' -1 day';
-			}
-			// If Tuesday (2) to Saturday (6)
-			elseif( $first_day_of_week > 1 ) {
-				$str = " +" . $first_day_of_week - 1 . " days";
-			}
-			return $str;
-		}
-
-		/**
-		 * Makes the day view jump to a specific date.
-		 *
-		 * @TODO Needs work
-		 *
-		 * @param $repository_args
-		 * @param $context
-		 * @param $view
-		 *
-		 * @return mixed
-		 */
-		function  jump_to_next_week( $repository_args, $context, $view )  {
-			$event_date = $context->get( 'event_date' );
-			//if ( ! $event_date ) {
-			if ( tribe_context()->get( 'view_request' ) === 'day' ) {
-				$context = $context->alter( [ 'event_date' => '2020-10-19' ] );
-				$view->set_context( $context );
+			if ( in_array( $day, $args['event_dates'] ) ) {
+				$args['day_classes'][] = 'has-event';
 			}
 
-			return $repository_args;
-		}
+			// Opening the day
+			$html .= '<div class="' . implode( " ", $args['day_classes'] ) . '">';
 
-		/**
-		 * Add dynamically calculated styles to the footer.
-		 */
-		public function footer_styles() {
-			$divider = $this->get_option( 'number_of_days' );
-			$behavior = $this->get_option( 'behavior' );
+			// URL
+			$html .= '<a href="' . tribe_events_get_url() . $day . '" data-js="tribe-events-view-link" aria-label="' . date( tribe_get_date_format( true ), strtotime( $day ) ) . '" title="' . date( tribe_get_date_format( true ), strtotime( $day ) ) . '">';
 
-			if ( $behavior == 'current_week' || $behavior == 'next_week' ) {
-				$divider = 7;
+			// Text part of the URL
+			// Name of day
+			$html .= '<span class="tribe-daystrip-dayname">';
+			if ( $args['day_name_length'] == -1 ) {
+				$html .= $date->format( 'l' );
 			}
-			$cellWidth = 100 / $divider;
-			?>
-			<style id="tribe-ext-daystrip-styles">
-                .tribe-events-header .tribe-daystrip-container .tribe-daystrip-day {
-				 width: <?php echo $cellWidth; ?>%;
-			 }
-			</style>
-			<?php
-		}
+			else {
+				$html .= substr( $date->format( 'l' ), 0, $args['day_name_length'] );
+			}
+			$html .= '</span>';
 
-		/**
-		 * Rendering the daystrip markup.
-		 *
-		 * @param array $args
-		 */
-		private function render_daystrip( array $args ) {
-
-			// Opening the strip
-			$html = '<div class="' . implode( " ", $args['container_classes'] ) . '">';
-
-			// Going through the array and setting up the strip
-			foreach ( $args['days'] as $day ) {
-				// Making a date object
-				$date = date_create( $day );
-
-				unset( $args['day_classes'] );
-				$args['day_classes'][] = 'tribe-daystrip-day';
-				// Setting class for past, today, and future events
-				if ( strtotime( $day ) < strtotime( $args['todays_date'] ) ) {
-					$args['day_classes'][] = 'tribe-daystrip-past';
-				} elseif ( strtotime( $day ) == strtotime( $args['todays_date'] ) ) {
-					$args['day_classes'][] = 'tribe-daystrip-today';
-				} elseif ( strtotime( $day ) > strtotime( $args['todays_date'] ) ) {
-					$args['day_classes'][] = 'tribe-daystrip-future';
-				}
-				// Setting class for selected day
-				if ( strtotime( $day ) == strtotime( $args['selected_date_value'] ) ) {
-					$args['day_classes'][] = 'tribe-daystrip-current';
-				}
-
-				if ( in_array( $day, $args['event_dates'] ) ) {
-					$args['day_classes'][] = 'has-event';
-				}
-
-				// Opening the day
-				$html .= '<div class="' . implode( " ",
-				                                   $args['day_classes'] ) . '">';
-
-				// URL
-				$html .= '<a href="' . tribe_events_get_url() . $day . '" data-js="tribe-events-view-link" aria-label="' . date( tribe_get_date_format( true ), strtotime( $day ) ) . '" title="' . date( tribe_get_date_format( true ), strtotime( $day ) ) . '">';
-
-				// Text part of the URL
-				// Name of day
-				$html .= '<span class="tribe-daystrip-dayname">';
-				if ( $args['day_name_length'] == -1 ) {
-					$html .= $date->format( 'l' );
-				}
-				else {
-					$html .= substr( $date->format( 'l' ), 0, $args['day_name_length'] );
-				}
+			// Date of day
+			if ( ! empty( $args['options']['date_format'] ) && $args['options']['date_format'] != '0' ) {
+				$html .= '<span class="tribe-daystrip-date">';
+				$html .= $date->format( $args['options']['date_format'] );
 				$html .= '</span>';
-
-				// Date of day
-				if ( ! empty( $args['options']['date_format'] ) && $args['options']['date_format'] != '0' ) {
-					$html .= '<span class="tribe-daystrip-date">';
-					$html .= $date->format( $args['options']['date_format'] );
-					$html .= '</span>';
-				}
-				if ( ! empty( $args['options']['month_format'] ) && $args['options']['month_format'] != '0' ) {
-					$html .= '<span class="tribe-daystrip-month">';
-					$html .= $date->format( $args['options']['month_format'] );
-					$html .= '</span>';
-				}
-
-				// Day has event marker
-				if ( ! $args['options']['hide_event_marker'] ) {
-					if ( in_array( $day, $args['event_dates'] ) ) {
-						$html .= '<em
-								class="tribe-events-calendar-day__daystrip-events-icon--event"
-								aria-label="Has event" title="Has event"></em>';
-					}
-				}
-
-				// Closing the URL
-				$html .= '</a>';
-
-				// Closing the day
-				$html .= '</div>';
+			}
+			if ( ! empty( $args['options']['month_format'] ) && $args['options']['month_format'] != '0' ) {
+				$html .= '<span class="tribe-daystrip-month">';
+				$html .= $date->format( $args['options']['month_format'] );
+				$html .= '</span>';
 			}
 
-			// Closing the strip
-			$html .= '</div>';
+			// Day has event marker
+			if ( ! $args['options']['hide_event_marker'] ) {
+				if ( in_array( $day, $args['event_dates'] ) ) {
+					$html .= '<em
+							class="tribe-events-calendar-day__daystrip-events-icon--event"
+							aria-label="Has event" title="Has event"></em>';
+				}
+			}
 
-			// Rendering the HTML
-			echo $html;
+			// Closing the URL
+			$html .= '</a>';
+
+			// Closing the day
+			$html .= '</div>';
 		}
-	} // end class
-} // end if class_exists check
+
+		// Closing the strip
+		$html .= '</div>';
+
+		// Rendering the HTML
+		echo $html;
+	}
+} // end class

--- a/tribe-ext-daystrip.php
+++ b/tribe-ext-daystrip.php
@@ -431,8 +431,8 @@ if ( class_exists( 'Tribe__Extension' ) && ! class_exists( Main::class ) ) {
 		 * Add dynamically calculated styles to the footer.
 		 */
 		public function footer_styles() {
-			$divider = $this->get_option( 'number_of_days' );
-			$behavior = $this->get_option( 'behavior' );
+			$divider = $this->get_option( 'number_of_days', 7 );
+			$behavior = $this->get_option( 'behavior', 'current_week' );
 
 			if ( $behavior == 'current_week' || $behavior == 'next_week' ) {
 				$divider = 7;


### PR DESCRIPTION
**This updates to a new major version!**

[TEC-4975](https://stellarwp.atlassian.net/browse/TEC-4975)

This incorporates 

- Make sure that all options have a default value so that the extension can be used right after activation.
- The day and month names show up on the day-to-day navigation bar from the start.
- The event marker now properly shows up on days with events. [EXT-311]
- Fix potential divide-by-string issue. 
- Tweak date format fields to accept an empty field as "don't show" (like entering a 0)
- There is now no warning message when saving the settings with an empty Start Date field.
- Numerous tweaks to better match our standards. 

Started to simplify the view check logic...
The logic was unnecessary. After slimming it down I realized it really just needed to require the v2 version of TEC. While we could point to the first version taht introduced v2, it seemed more reasonable to bump the version to the legacy view deprecation. (6.0+)

The extension has been updated to require the 6.0 version of TEC and all the view checking logic has been removed.